### PR TITLE
Fix looping bug on shadowbanned users

### DIFF
--- a/automoderator.py
+++ b/automoderator.py
@@ -341,22 +341,27 @@ class Condition(object):
                 compare = rank_values[compare]
 
             if user:
-                if attr == 'rank':
-                    value = rank_values[get_user_rank(user, item.subreddit)]
-                elif attr == 'account_age':
-                    user_date = datetime.utcfromtimestamp(user.created_utc)
-                    value = (datetime.utcnow() - user_date).days
-                elif attr == 'combined_karma':
-                    value = user.link_karma + user.comment_karma
-                else:
-                    try:
+                try:
+                    if attr == 'rank':
+                        value = rank_values[get_user_rank(user, item.subreddit)]
+                    elif attr == 'account_age':
+                        user_date = datetime.utcfromtimestamp(user.created_utc)
+                        value = (datetime.utcnow() - user_date).days
+                    elif attr == 'combined_karma':
+                        value = user.link_karma + user.comment_karma
+                    else:
                         value = getattr(user, attr, 0)
-                    except HTTPError as e:
-                        if e.response.status_code == 404:
-                            # user is shadowbanned, never satisfies conditions
-                            return False
-                        else:
-                            raise
+                except HTTPError as e:
+                    if e.response.status_code == 404:
+                        # user is shadowbanned, never satisfies conditions
+                        logging.debug("User /u/{} has been shadowbanned or deleted their account."
+                                      .format(user.name))
+                        return False
+                    else:
+                        # Non-404 probably means temporary reddit server availability issues
+                        # Should probably find a more elegant way to re-check here instead
+                        # of raising an error and looping.
+                        raise
             else:
                 value = 0
                 


### PR DESCRIPTION
This is a relatively simple fix for a massively debilitating bug which prevents the current release from being usable.

Pre-patch, any attempt to check user conditions except for `rank`, `account_age`, or `combined_karma` would produce an uncaught 404 error when retrieving data for a shadowbanned (or self-deleted) user account. This exception bubbled up to the primary execution loop, broke out of the current queue checking operation, and caused the entire queue checking process to be restarted from the beginning without updating the database `last_*` values. This sent the script into a spiral of repeated checking of all queue items back to the problem queue item, with the number of items to check increasing exponentially with the time required to check them.

This patch addresses the issue.