### PR TITLE
Reusable constants and rules referencing them, managed on separate wiki pages

### DIFF
--- a/automoderator.cfg.example
+++ b/automoderator.cfg.example
@@ -40,6 +40,8 @@ password = reddit_password
 report_backlog_limit_hours = 48
 reports_check_period_mins = 10
 wiki_page_name = %(username)s
+rules_wiki_page_name = AutoModRules
+constants_wiki_page_name = AutoModConstants
 last_message = 1356998400
 disclaimer = *[I am a bot](/r/AutoModerator/comments/q11pu/what_is_automoderator/), and this action was performed automatically. Please [contact the moderators of this subreddit](/message/compose?to=%%2Fr%%2F{{subreddit}}) if you have any questions or concerns.*
 owner_username = your_username


### PR DESCRIPTION
This is supposed to solve the issues brought up in #13 and here: http://www.reddit.com/r/AutoModerator/comments/2smxva/feature_request_constants_or_variables_for_reused/

The regular AutoModerator workflow is unaffected. Only if the AutomodConstants and AutomodRules wiki pages do exist will the bot try to preprocess these pages and write the result to the Automoderator wiki page. From that point the process is the same as if the Automoderator wiki page would have been manually edited.

Here are some use cases where this might be useful:

https://github.com/green-flash/AutoModerator/wiki/Reusable-constants-for-AutoModerator